### PR TITLE
Set up cibuildgem to ship this gem with precompiled binaries:

### DIFF
--- a/.github/workflows/cibuildgem.yaml
+++ b/.github/workflows/cibuildgem.yaml
@@ -1,0 +1,87 @@
+name: "Package and release gems with precompiled binaries"
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: "If the whole build passes on all platforms, release the gems on RubyGems.org"
+        required: false
+        type: boolean
+        default: false
+jobs:
+  compile:
+    timeout-minutes: 20
+    name: "Cross compile the gem on different ruby versions"
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-22.04"]
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v5"
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "3.1.7"
+          bundler-cache: true
+      - name: "Run cibuildgem"
+        uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
+        with:
+          step: "compile"
+  test:
+    timeout-minutes: 20
+    name: "Run the test suite"
+    needs: compile
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-22.04"]
+        rubies: ["3.3", "3.4", "4.0"]
+        type: ["cross", "native"]
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v5"
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "${{ matrix.rubies }}"
+          bundler-cache: true
+      - name: "Run cibuildgem"
+        uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
+        with:
+          step: "test_${{ matrix.type }}"
+  install:
+    timeout-minutes: 5
+    name: "Verify the gem can be installed"
+    needs: test
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-22.04"]
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "4.0.0"
+      - name: "Run cibuildgem"
+        uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
+        with:
+          step: "install"
+  release:
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+    timeout-minutes: 5
+    if: ${{ inputs.release }}
+    name: "Release all gems with RubyGems"
+    needs: install
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "4.0.0"
+      - name: "Run cibuildgem"
+        uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
+        with:
+          step: "release"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,7 @@ GEM
       rake
 
 PLATFORMS
-  arm64-darwin-22
-  arm64-darwin-25
+  arm64-darwin
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/djb2.rb
+++ b/lib/djb2.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 require_relative "djb2/version"
-require "djb2/djb2"
+
+begin
+  # Load the precompiled version of the library
+  ruby_version = /(\d+\.\d+)/.match(RUBY_VERSION)
+  require "djb2/#{ruby_version}/djb2"
+rescue LoadError
+  # It's important to leave for users that can not or don't want to use the gem with precompiled binaries.
+  require "djb2/djb2"
+end
 
 module DJB2
   class Error < StandardError; end


### PR DESCRIPTION
- The worfklow was generated using `cibuildgem ci_template`.

  The only change required in the gem itself is loading the binary for the right ruby version, due to the fat gem limitation problem we have in the rubygem ecosystem.