### PR TITLE
Add release workflow using RubyGems Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  push:
+    name: Push gem to RubyGems.org
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1.288.0
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+      - uses: rubygems/release-gem@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
     name: Push gem to RubyGems.org
     runs-on: ubuntu-latest
 
+    environment: release
+
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ jobs:
     environment: release
 
     permissions:
+      contents: read
       id-token: write
-      contents: write
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release.yml` that triggers on version tags (`v*`) and uses the [`rubygems/release-gem`](https://github.com/rubygems/release-gem) action with OIDC Trusted Publishing to push gems to RubyGems.org.
- No long-lived API tokens or secrets needed — GitHub's OIDC identity provider handles authentication automatically.

## Usage

```
git tag v0.2.0
git push origin v0.2.0
```